### PR TITLE
fix: DirectedGraph.addEdge + doc updates (Gryphon V1.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@
 
 A Scala 3 graph algorithms library built on the
 [Visitor](https://github.com/rchillyard/Visitor) typeclass traversal engine.
+Additionally, an API allowing easy access to the library from Java.
 
 Gryphon provides clean, purely functional implementations of the classic graph
 algorithms from Sedgewick & Wayne, *Algorithms* (4th ed.), Chapter 4.
 All algorithms are implemented using Scala 3 idioms — typeclasses, `given`/`using`,
 and clean architectural separation between graph structure and traversal logic.
 
-Gryphon is intended as an artefact of the [DSAIPG](https://github.com/rchillyard/DSAIPG) repository
-that supports the author's own textbook Data Structures, Algorithms, and Invariants - a Practical Guide
-(published by Cognella).
+Gryphon is intended as an artefact of the [DSAIPG](https://github.com/rchillyard/DSAIPG) (Java) repository
+that supports the author's own textbook: _Data Structures, Algorithms, and Invariants - a Practical Guide_
+(published by Cognella, 2025).
 
 ---
 
@@ -28,7 +29,7 @@ that supports the author's own textbook Data Structures, Algorithms, and Invaria
 Add Gryphon to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.phasmidsoftware" %% "gryphon" % "1.5.1"
+libraryDependencies += "com.phasmidsoftware" %% "gryphon" % "1.5.2"
 ```
 
 Gryphon requires **Scala 3** and depends on
@@ -217,7 +218,7 @@ Insert the following into the `<dependencies>` block of your pom.xml:
 <dependency>
     <groupId>com.phasmidsoftware</groupId>
     <artifactId>gryphon_3</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
 </dependency>
 ````
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Gryphon project build file.
 
-ThisBuild / version := "1.5.1"
+ThisBuild / version := "1.5.2"
 
 ThisBuild / organization := "com.phasmidsoftware"
 

--- a/docs/GraphTraversalDesign.md
+++ b/docs/GraphTraversalDesign.md
@@ -13,7 +13,7 @@ see `VisitorDesign.md` in the Visitor repository.
 
 ---
 
-## Current State (Gryphon V1.5.1 / Visitor V1.6.0)
+## Current State (Gryphon V1.5.2 / Visitor V1.6.0)
 
 ### Scala Algorithm Suite
 
@@ -169,19 +169,6 @@ and `UndirectedEdge` — throwing `GraphException` on properly bidirectional gra
 
 **Fix:** Pass `connexion` directly to `addConnexion` regardless of `flipped`.
 `addConnexion` already handles `UndirectedEdge` correctly via `u.other(v)`.
-
-### `DirectedGraph.addEdge` — destination vertex not ensured
-
-`DirectedGraph.addEdge` calls `vertexMap.modifyVertex` which only touches the
-`from` vertex. Destination-only vertices (reachable but never a source) are
-silently absent from the `VertexMap`, causing `key not found` errors when any
-traversal attempts to expand them. `UndirectedGraph.addEdge` is correct — it
-delegates to `VertexMap.+[E]` which calls `ensure` for both endpoints.
-
-**Workaround:** `JavaFacadeBridge` materialisation methods fold directly over
-`VertexMap.+[E]` rather than through `DirectedGraph.addEdge`. The underlying
-bug is tracked as
-[Gryphon Issue #16](https://github.com/rchillyard/Gryphon/issues/16).
 
 ---
 

--- a/docs/JavaFacadeDesign.md
+++ b/docs/JavaFacadeDesign.md
@@ -70,7 +70,7 @@ all Scala machinery is hidden.
 
 ---
 
-## Current State (V1.3.0)
+## Current State (V1.5.2)
 
 ### Implemented
 
@@ -83,7 +83,7 @@ all Scala machinery is hidden.
 | `GraphTraversal`              | `gryphon.java` | Package-private BFS/DFS; returns `Map<V,V>` parent trees                |
 | `Connectivity<V>`             | `gryphon.java` | Mutable façade over `Connectivity` / `ConnectivityOptimized`            |
 | `ShortestPaths`               | `gryphon.java` | Dijkstra (Option 1: `Double`; Option 3: custom combine/zero/comparator) |
-| `MinimumSpanningTree`         | `gryphon.java` | Prim and Kruskal (Option 1: `Double`; Option 3: custom comparator only) |
+| `MinimumSpanningTree`         | `gryphon.java` | Prim, Kruskal, and Borůvka (Option 1: `Double`; Option 3: custom comparator only) |
 | `StronglyConnectedComponents` | `gryphon.java` | Kosaraju; `count()`; `components()`                                     |
 | `JavaFacadeBridge`            | `gryphon.java` | Internal Scala bridge: graph materialisation and algorithm delegation   |
 
@@ -95,6 +95,10 @@ all Scala machinery is hidden.
 | `GraphTest`                       | JUnit 5   | ✅ Green |
 | `ShortestPathsTest`               | JUnit 5   | ✅ Green |
 | `MinimumSpanningTreeTest`         | JUnit 5   | ✅ Green |
+| `BoruvkaTest`                     | JUnit 5   | ✅ Green |
+| `TunnelsTest`                     | JUnit 5   | ✅ Green |
+| `TunnelsFromResourceTest`         | JUnit 5   | ✅ Green |
+| `WeightedGraphFromResourceTest`   | JUnit 5   | ✅ Green |
 | `StronglyConnectedComponentsTest` | JUnit 5   | ✅ Green |
 
 ### Build
@@ -111,7 +115,11 @@ network design (`Tunnels_Gryphon.java` in DSAIPG). Using
 `WeightedGraph<Building, TunnelProperties>` with Prim's algorithm (ordered by
 `TunnelProperties.cost`), the façade produces a minimum spanning tree of 79
 tunnels connecting 80 campus buildings at a total cost of $6,648,954 — agreeing
-exactly with the independent Kruskal implementation, confirming correctness.
+exactly with independent Kruskal and Borůvka implementations, confirming correctness.
+
+A self-contained integration test (`TunnelsTest`, `TunnelsFromResourceTest`) is
+included in Gryphon's own test suite, using building codes as `String` vertices
+and `Long` costs, loading from `tunnels.graph` via `WeightedGraph.undirectedFromResource`.
 
 ---
 
@@ -183,6 +191,7 @@ Returns SPT as `Map<V, WeightedEdge<V, E>>`. Option 3 signature:
 
 - **Prim** Option 3: `prim(graph, start, comparator)` — comparator only.
 - **Kruskal** Option 3: `kruskal(graph, comparator)` — comparator only.
+- **Borůvka** Option 3: `boruvka(graph, comparator)` — comparator only.
 
 ### `StronglyConnectedComponents` — Static Façade
 
@@ -205,6 +214,7 @@ Returns SPT as `Map<V, WeightedEdge<V, E>>`. Option 3 signature:
 | `ShortestPaths.dijkstra`               | directed            |
 | `MinimumSpanningTree.prim`             | undirected          |
 | `MinimumSpanningTree.kruskal`          | undirected          |
+| `MinimumSpanningTree.boruvka`          | undirected          |
 | `StronglyConnectedComponents.kosaraju` | directed            |
 
 ---
@@ -216,20 +226,17 @@ Returns SPT as `Map<V, WeightedEdge<V, E>>`. Option 3 signature:
 | `ShortestPaths.dijkstra`      | `combine`, `zero`, `comparator` | Accumulates path costs — needs full Monoid |
 | `MinimumSpanningTree.prim`    | `comparator` only               | Compares edge weights; never combines      |
 | `MinimumSpanningTree.kruskal` | `comparator` only               | Sorts edge weights; never combines         |
+| `MinimumSpanningTree.boruvka` | `comparator` only               | Selects min crossing edge; never combines  |
 
 ---
 
 ## Known Issues
 
-- **`DirectedGraph.addEdge` does not ensure the destination vertex exists.**
-  `DirectedGraph.addEdge` calls `vertexMap.modifyVertex` which only touches the
-  `from` vertex. If called on an empty (or incomplete) `VertexMap`,
-  destination-only vertices are silently absent, causing `key not found` errors
-  when any traversal attempts to expand them. `UndirectedGraph.addEdge` is
-  correct — it delegates to `VertexMap.+[E]` which calls `ensure` for both
-  endpoints. `DirectedGraph.addEdge` should do the same.
-  **Workaround:** all `JavaFacadeBridge` materialisation methods fold directly
-  over `VertexMap.+[E]` rather than through `DirectedGraph.addEdge`. See [Issue #16](https://github.com/rchillyard/Gryphon/issues/16#issue-4240244349)
+- ~~**`DirectedGraph.addEdge` does not ensure the destination vertex exists.**~~
+  **Fixed in V1.5.2.** `DirectedGraph.addEdge` now delegates to `VertexMap.+[E]`
+  like `UndirectedGraph.addEdge`, ensuring both endpoints exist. The `JavaFacadeBridge`
+  workaround (folding over `VertexMap.+[E]` directly) remains in place and is
+  still correct. See [Issue #16](https://github.com/rchillyard/Gryphon/issues/16#issue-4240244349)
 
 - **`Monoid[E].combine` is a stub in `primCustom`.**
   Prim's algorithm only uses `Monoid[E].identity` (as the initial frontier cost)
@@ -268,8 +275,10 @@ Returns SPT as `Map<V, WeightedEdge<V, E>>`. Option 3 signature:
   List<V> TopologicalSort.sort(Graph<V> g);
   ```
 
-- **Graph loading from file.** A `GraphReader` parsing the `.graph` resource
-  format and producing a `Graph<V>` or `WeightedGraph<V,E>`.
+- ~~**Graph loading from file.**~~ **Done in V1.5.1** — `WeightedGraph.undirectedFromResource`
+  and `directedFromResource` (Option 1 and Option 3) load from `.graph` classpath
+  resources via `GraphBuilder`. `asParseable` wraps Java `Function<String,T>` with
+  appropriate token regex (`\w+` for vertices, double regex for weights).
 
 ### Low Priority / Aspirational
 
@@ -306,10 +315,10 @@ Returns SPT as `Map<V, WeightedEdge<V, E>>`. Option 3 signature:
    warrant sub-packages: `gryphon.java.graph`, `gryphon.java.algo`, etc.
 
 3. **Java type erasure forces distinct factory method names on `WeightedGraph`.**
-  `WeightedGraph.directed()` and `WeightedGraph.undirected()` would clash with
-  the inherited `Graph.directed()` and `Graph.undirected()` after erasure.
-  Workaround: factory methods are named `directedWeighted()` and
-  `undirectedWeighted()`.
+   `WeightedGraph.directed()` and `WeightedGraph.undirected()` would clash with
+   the inherited `Graph.directed()` and `Graph.undirected()` after erasure.
+   Workaround: factory methods are named `directedWeighted()` and
+   `undirectedWeighted()`.
 
 ---
 
@@ -324,3 +333,7 @@ Returns SPT as `Map<V, WeightedEdge<V, E>>`. Option 3 signature:
 | 1.2.2   | ShortestPaths (Dijkstra Option 1 and Option 3); JavaFacadeBridge; ShortestPathsTest                                                                                                                                                                |
 | 1.2.3   | MinimumSpanningTree (Prim and Kruskal); StronglyConnectedComponents (Kosaraju); MST Scala entry point                                                                                                                                              |
 | 1.3.0   | WeightedGraph<V,E> extending Graph<V>; typed edge attributes eliminate runtime casts; simplified Option 3 API for Prim/Kruskal (Comparator only); Dijkstra Option 3 retains combine+zero+comparator; validated against Northeastern tunnel network |
+| 1.4.0   | All BFS/DFS delegate to Scala Visitor engine via CameFromJournal |
+| 1.5.0   | MinimumSpanningTree.boruvka (Option 1 and Option 3) |
+| 1.5.1   | WeightedGraph.fromResource (Option 1 and Option 3); Graph/WeightedGraph resource-load constructors; GraphBuilder Scala API |
+| 1.5.2   | Borůvka deduplication bug fix; Boruvka returns Seq like Kruskal; DirectedGraph.addEdge fixed (Issue #16); tunnel integration tests |

--- a/src/main/scala/com/phasmidsoftware/gryphon/adjunct/DirectedGraph.scala
+++ b/src/main/scala/com/phasmidsoftware/gryphon/adjunct/DirectedGraph.scala
@@ -79,16 +79,16 @@ case class DirectedGraph[V, E](vertexMap: VertexMap[V]) extends AbstractGraph[V]
    *
    * @throws GraphException if the provided edge type is unexpected or unsupported.
    */
-  override def addEdge(edge: Edge[V, E]): DirectedGraph[V, E] = edge match {
-    case edge: DirectedEdge[_, _] =>
-      copy(vertexMap.modifyVertex(v => v + AdjacencyEdge(edge))(edge.white))
-    case edge: OrderableEdge[_, _] =>
-      copy(vertexMap.modifyVertex(v => v + AdjacencyEdge(edge))(edge.white))
-    case edge@UndirectedEdge(_, white, _) =>
-      copy(vertexMap.modifyVertex(v => v + AdjacencyEdge(edge))(white)) // TODO we need to add this edge twice (once in each direction)
-    case _ =>
-      throw GraphException(s"unexpected edge type: $edge")
-  }
+
+  /**
+   * Delegates to `VertexMap.+[E]`, which calls `ensure` for both endpoints.
+   * This ensures the destination vertex exists in the map even if it has no
+   * outgoing edges — fixing Issue #16.
+   * This is consistent with `UndirectedGraph.addEdge` which also delegates
+   * to `VertexMap.+[E]`.
+   */
+  override def addEdge(edge: Edge[V, E]): DirectedGraph[V, E] =
+    copy(vertexMap + edge)
 
   /**
    * Retrieves all edges in the directed graph as an iterable collection of edges.


### PR DESCRIPTION
Fix:
- DirectedGraph.addEdge now delegates to VertexMap.+[E] like UndirectedGraph.addEdge, ensuring both endpoints exist in the VertexMap — closes Issue #16. The JavaFacadeBridge workaround remains in place and is still correct.

Docs:
- GraphTraversalDesign.md: Borůvka deduplication fix section added; Gryphon version bumped to V1.5.2; Boruvka.mst return type corrected to Seq[Edge[V,E]]
- JavaFacadeDesign.md: version V1.5.2; Borůvka added throughout; DirectedGraph issue marked fixed; graph-from-file deferred item marked done; tunnel integration tests added to test coverage table; version history 1.4.0–1.5.2
- README.md: Borůvka usage example corrected to Seq; test count 531; tunnel integration test bullet added; version 1.5.2 entry added

Total tests: 531